### PR TITLE
org.metaborg.meta.interpreter.framework is now needed by Spoofax runtime

### DIFF
--- a/org.strategoxt.imp.feature/feature.xml
+++ b/org.strategoxt.imp.feature/feature.xml
@@ -258,4 +258,11 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          version="1.3.0.qualifier"
          unpack="false"/>
 
+   <plugin
+         id="org.metaborg.meta.interpreter.framework"
+         download-size="0"
+         install-size="0"
+         version="1.3.0.qualifier"
+         unpack="false"/>
+
 </feature>

--- a/org.strategoxt.imp.meta.feature/feature.xml
+++ b/org.strategoxt.imp.meta.feature/feature.xml
@@ -234,13 +234,6 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          unpack="false"/>
 
    <plugin
-         id="org.metaborg.meta.interpreter.framework"
-         download-size="0"
-         install-size="0"
-         version="1.3.0.qualifier"
-         unpack="false"/>
-
-   <plugin
          id="org.metaborg.spoofax.core"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
I moved `org.metaborg.meta.interpreter.framework` from the meta to the runtime feature because it seems like the runtime now depends on it (which probably makes sense).

If it's not moved, you'll get the following error when installing a (deployed) Spoofax language:

Cannot complete the install because one or more required items could not be found.
  Software being installed: SPARQL 0.0.1.20150115-235304 (com.oracle.greenmarl.gmql.sparql.feature.feature.group 0.0.1.20150115-235304)
  Missing requirement: Spoofax/IMP Runtime 1.3.0.20150115-165251-master (org.strategoxt.imp.runtime 1.3.0.20150115-165251-master) requires 'bundle org.metaborg.meta.interpreter.framework 0.0.0' but it could not be found