### PR TITLE
Spoofax Eclipse 1.4.0 => 1.4.1

### DIFF
--- a/org.metaborg.build/src/metaborg/releng/cmd.py
+++ b/org.metaborg.build/src/metaborg/releng/cmd.py
@@ -12,7 +12,7 @@ from metaborg.util.path import CommonPrefix
 
 class MetaborgReleng(cli.Application):
   PROGNAME = 'releng'
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 
   repoDirectory = '.'
   repo = None

--- a/org.metaborg.maven.build.java/pom.xml
+++ b/org.metaborg.maven.build.java/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.build.parentpoms.plugin/pom.xml
+++ b/org.metaborg.maven.build.parentpoms.plugin/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.build.parentpoms/pom.xml
+++ b/org.metaborg.maven.build.parentpoms/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.build.spoofax.eclipse/pom.xml
+++ b/org.metaborg.maven.build.spoofax.eclipse/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.build.spoofax.libs/pom.xml
+++ b/org.metaborg.maven.build.spoofax.libs/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.build.spoofax.testrunner/pom.xml
+++ b/org.metaborg.maven.build.spoofax.testrunner/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.parent.java/pom.xml
+++ b/org.metaborg.maven.parent.java/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.parent.language/pom.xml
+++ b/org.metaborg.maven.parent.language/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.parent.plugin/pom.xml
+++ b/org.metaborg.maven.parent.plugin/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent</relativePath>
 	</parent>
 

--- a/org.metaborg.maven.parent/pom.xml
+++ b/org.metaborg.maven.parent/pom.xml
@@ -7,7 +7,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.metaborg</groupId>
   <artifactId>org.metaborg.maven.parent</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1</version>
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Maven parent POM for all projects</description>
@@ -23,7 +23,7 @@
 
     <java-version>1.7</java-version>
     <maven-eclipse-compiler-version>2.3</maven-eclipse-compiler-version>
-    <metaborg-version>1.4.0</metaborg-version>
+    <metaborg-version>1.4.1</metaborg-version>
     <jline-version>0.9.94</jline-version>
   </properties>
 

--- a/org.spoofax.modelware.emf.feature/feature.xml
+++ b/org.spoofax.modelware.emf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.metaborg.modelware.emf"
       label="Spoofax EMF Integration (runtime support only)"
-      version="1.4.0">
+      version="1.4.1">
 
    <description url="http://metaborg.org/wiki/spoofax/">
       Spoofax EMF Integration provides integration between Spoofax and the Eclipse Modeling Framework (EMF).
@@ -21,14 +21,14 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
 
    <includes
          id="org.strategoxt.imp"
-         version="1.4.0"
+         version="1.4.1"
          search-location="both"/>
 
    <plugin
          id="org.spoofax.modelware.emf"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
 </feature>

--- a/org.spoofax.modelware.emf.feature/pom.xml
+++ b/org.spoofax.modelware.emf.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.spoofax.modelware.emf.meta.feature/feature.xml
+++ b/org.spoofax.modelware.emf.meta.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.metaborg.modelware.emf.meta"
       label="Spoofax EMF Integration"
-      version="1.4.0">
+      version="1.4.1">
 
    <description url="http://metaborg.org/wiki/spoofax/">
       Spoofax EMF Integration provides integration between Spoofax and the Eclipse Modeling Framework (EMF).
@@ -21,7 +21,7 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
 
    <includes
          id="org.strategoxt.imp.meta"
-         version="1.4.0"
+         version="1.4.1"
          search-location="both"/>
 
    <includes

--- a/org.spoofax.modelware.emf.meta.feature/pom.xml
+++ b/org.spoofax.modelware.emf.meta.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.spoofax.modelware.gmf.feature/feature.xml
+++ b/org.spoofax.modelware.gmf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.metaborg.modelware.gmf"
       label="Spoofax GMF Integration (runtime support only)"
-      version="1.4.0">
+      version="1.4.1">
 
    <description url="http://metaborg.org/wiki/spoofax/">
       Spoofax GMF integration provides integration between Spoofax and the Graphical Modeling Framework (GMF) in order to support real-time synchronized views and/or editors for Spoofax.
@@ -27,7 +27,7 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          id="org.spoofax.modelware.gmf"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
 </feature>

--- a/org.spoofax.modelware.gmf.feature/pom.xml
+++ b/org.spoofax.modelware.gmf.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.spoofax.modelware.gmf.headless.feature/feature.xml
+++ b/org.spoofax.modelware.gmf.headless.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.metaborg.modelware.gmf.headless"
       label="Headless support for GMF code generation"
-      version="1.4.0">
+      version="1.4.1">
 
    <description url="http://metaborg.org/wiki/spoofax/">
       Spoofax GMF integration provides integration between Spoofax and the Graphical Modeling Framework (GMF) in order to support real-time synchronized views and/or editors for Spoofax.
@@ -29,7 +29,7 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          id="org.spoofax.modelware.gmf.codegenextension"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
 </feature>

--- a/org.spoofax.modelware.gmf.headless.feature/pom.xml
+++ b/org.spoofax.modelware.gmf.headless.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.spoofax.modelware.gmf.meta.feature/feature.xml
+++ b/org.spoofax.modelware.gmf.meta.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.metaborg.modelware.gmf.meta"
       label="Spoofax GMF Integration"
-      version="1.4.0">
+      version="1.4.1">
 
    <description url="http://metaborg.org/wiki/spoofax/">
       Spoofax GMF integration provides integration between Spoofax and the Graphical Modeling Framework (GMF) in order to support real-time synchronized views and/or editors for Spoofax.

--- a/org.spoofax.modelware.gmf.meta.feature/pom.xml
+++ b/org.spoofax.modelware.gmf.meta.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.strategoxt.imp.feature/feature.xml
+++ b/org.strategoxt.imp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.strategoxt.imp"
       label="Spoofax Runtime"
-      version="1.4.0"
+      version="1.4.1"
       plugin="org.strategoxt.imp.runtime">
 
    <description url="http://metaborg.org/spoofax/">
@@ -68,76 +68,76 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          id="org.spoofax.terms"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.library.index"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.core"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.metaborg.util"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.library.jline"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.spoofax.interpreter.library.eclipse"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.adapter.ecj"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.library.java"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.library.xml"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.library.interpreter"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
   <!-- External deps have to be unpacked so that we can provide nested Jars on the classpath when building language plugins -->
@@ -145,124 +145,124 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          id="org.spoofax.interpreter.externaldeps"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.metaborg.runtime.task"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.interpreter.library.jsglr"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.jsglr"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.strj"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.runtime"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.generator"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.nativebundle"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.runtime.sidebyside.latest"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.runtime.sidebyside.main"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.debug.core"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.debug.stratego.core"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.debug.stratego.runtime"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.debug.stratego.transformer"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="lpg.runtime"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.eclipse.imp.runtime"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.jarprovider"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.spoofax.interpreter.ui"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.metaborg.meta.interpreter.framework"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
 </feature>

--- a/org.strategoxt.imp.feature/pom.xml
+++ b/org.strategoxt.imp.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.strategoxt.imp.meta.feature/feature.xml
+++ b/org.strategoxt.imp.meta.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.strategoxt.imp.meta"
       label="Spoofax Core"
-      version="1.4.0"
+      version="1.4.1"
       plugin="org.strategoxt.imp.runtime">
 
    <description url="http://metaborg.org/spoofax/">
@@ -28,7 +28,7 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
 
    <includes
          id="org.strategoxt.imp"
-         version="1.4.0"
+         version="1.4.1"
          search-location="both"/>
 
    <requires>
@@ -73,191 +73,191 @@ Most Spoofax/IMP code is licensed under the GNU Lesser General Public License (L
          id="org.strategoxt.imp.editors.sdf"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.editors.template"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.editors.stratego"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.editors.editorservice"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.editors.aterm"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.editors.aster"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.editors.pp"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.editors.rtg"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.metaborg.meta.lang.analysis"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.metaborg.meta.lang.nabl"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.metaborg.meta.lang.ts"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="dynsem"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.testing"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.testing.ui"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="com.ibm.wala.shrike"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.java.hosted"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.metatooling"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.preferences"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.prefspecs"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.presentation"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.lpg"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.smapi"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.smapifier"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.lpg.ide"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.imp.xform"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.metaborg.spoofax.core"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.spoofax.aterm"
          download-size="0"
          install-size="0"
-         version="1.4.0"/>
+         version="1.4.1"/>
 
    <plugin
          id="org.strategoxt.imp.debug.ui"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
    <plugin
          id="org.strategoxt.imp.metatooling"
          download-size="0"
          install-size="0"
-         version="1.4.0"
+         version="1.4.1"
          unpack="false"/>
 
 </feature>

--- a/org.strategoxt.imp.meta.feature/pom.xml
+++ b/org.strategoxt.imp.meta.feature/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.strategoxt.imp.updatesite/pom.xml
+++ b/org.strategoxt.imp.updatesite/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.metaborg</groupId>
 		<artifactId>org.metaborg.maven.parent.plugin</artifactId>
-		<version>1.4.0</version>
+		<version>1.4.1</version>
 		<relativePath>../org.metaborg.maven.parent.plugin</relativePath>
 	</parent>
 

--- a/org.strategoxt.imp.updatesite/site.xml
+++ b/org.strategoxt.imp.updatesite/site.xml
@@ -3,19 +3,19 @@
    <description name="Spoofax/IMP" url="http://spoofax.org/update/stable/">
       Spoofax update site
    </description>
-   <feature url="features/org.strategoxt.imp.meta_1.4.0.jar" id="org.strategoxt.imp.meta" version="1.4.0">
+   <feature url="features/org.strategoxt.imp.meta_1.4.1.jar" id="org.strategoxt.imp.meta" version="1.4.1">
       <category name="Spoofax Core"/>
    </feature>
-   <feature url="features/org.strategoxt.imp_1.4.0.jar" id="org.strategoxt.imp" version="1.4.0">
+   <feature url="features/org.strategoxt.imp_1.4.1.jar" id="org.strategoxt.imp" version="1.4.1">
       <category name="Spoofax Core"/>
    </feature>
-   <feature url="features/org.metaborg.modelware.emf.meta_1.4.0.jar" id="org.metaborg.modelware.emf.meta" version="1.4.0">
+   <feature url="features/org.metaborg.modelware.emf.meta_1.4.1.jar" id="org.metaborg.modelware.emf.meta" version="1.4.1">
       <category name="Spoofax Modelware"/>
    </feature>
-   <feature url="features/org.metaborg.modelware.gmf.headless_1.4.0.jar" id="org.metaborg.modelware.gmf.headless" version="1.4.0">
+   <feature url="features/org.metaborg.modelware.gmf.headless_1.4.1.jar" id="org.metaborg.modelware.gmf.headless" version="1.4.1">
       <category name="Spoofax Modelware"/>
    </feature>
-   <feature url="features/org.metaborg.modelware.gmf.meta_1.4.0.jar" id="org.metaborg.modelware.gmf.meta" version="1.4.0">
+   <feature url="features/org.metaborg.modelware.gmf.meta_1.4.1.jar" id="org.metaborg.modelware.gmf.meta" version="1.4.1">
       <category name="Spoofax Modelware"/>
    </feature>
    <category-def name="Spoofax Core" label="Spoofax Core">


### PR DESCRIPTION
I couldn't create an Eclipse plugin for my language because Spoofax 1.4.1 plugins still had version 1.4.0. This pull request fixes that. It's tested with `./releng build -p all`.