### PR TITLE
Add SPT Eclipse TestRunner to spt build.

### DIFF
--- a/build/language/spt/pom.xml
+++ b/build/language/spt/pom.xml
@@ -26,6 +26,8 @@
     <module>${repo.root}/spt/org.metaborg.spt.cmd</module>
     <module>${repo.root}/spt/org.metaborg.meta.lang.spt</module>
     <module>${repo.root}/spt/org.metaborg.meta.lang.spt.interactive</module>
+    <module>${repo.root}/spt/org.metaborg.lang.minisql</module>
+    <module>${repo.root}/spt/org.metaborg.spt.testrunner.eclipse</module>
   </modules>
 
   <developers>


### PR DESCRIPTION
This PR adds the Eclipse testrunner project of SPT to the build entries for spt.

It also adds a new language to the build entries for SPT.
See https://github.com/metaborg/spt/pull/15 for details on that.