### PR TITLE
Stratego incremental compilation

### DIFF
--- a/build/java/pom.xml
+++ b/build/java/pom.xml
@@ -59,7 +59,7 @@
     <module>${repo.root}/nabl/statix.solver</module>
 
     <!-- StrategoXT -->
-    <module>${repo.root}/stratego/stratego.typed.pack/pom.xml</module>
+    <module>${repo.root}/stratego/stratego.compiler.pack/pom.xml</module>
     <module>${repo.root}/strategoxt/strategoxt/stratego-libraries/java-backend</module>
 
     <!-- SPT -->

--- a/build/java/pom.xml
+++ b/build/java/pom.xml
@@ -59,6 +59,7 @@
     <module>${repo.root}/nabl/statix.solver</module>
 
     <!-- StrategoXT -->
+    <module>${repo.root}/stratego/stratego.typed.pack/pom.xml</module>
     <module>${repo.root}/strategoxt/strategoxt/stratego-libraries/java-backend</module>
 
     <!-- SPT -->

--- a/parent/eclipse/plugin/pom.xml
+++ b/parent/eclipse/plugin/pom.xml
@@ -139,6 +139,11 @@
       <artifactId>org.strategoxt.strj</artifactId>
       <version>${metaborg-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.metaborg</groupId>
+      <artifactId>stratego.typed.pack</artifactId>
+      <version>${metaborg-version}</version>
+    </dependency>
     <!-- Interpretation -->
     <dependency>
       <groupId>org.metaborg</groupId>

--- a/parent/eclipse/plugin/pom.xml
+++ b/parent/eclipse/plugin/pom.xml
@@ -141,7 +141,7 @@
     </dependency>
     <dependency>
       <groupId>org.metaborg</groupId>
-      <artifactId>stratego.typed.pack</artifactId>
+      <artifactId>stratego.compiler.pack</artifactId>
       <version>${metaborg-version}</version>
     </dependency>
     <!-- Interpretation -->


### PR DESCRIPTION
This set of PRs adds an incremental compilation option for Stratego. A clean build takes a while, but a small change is compiled faster than putting the compiler in CTree mode, despite separate compilation generating a JAR of fully compiled Stratego (which should in principle still be faster in execution than CTree). 
Known limitations of the current implementation for incremental compilation are:
- Overlays are not supported
- Mix-syntax (Stratego with concrete syntax mix-ins) is not tested yet
- Ctree/RTree include files are not supported

PR list:
https://github.com/metaborg/spoofax/pull/39
https://github.com/metaborg/spoofax-deploy/pull/17
https://github.com/metaborg/spoofax-eclipse/pull/14
https://github.com/metaborg/strategoxt/pull/25