### PR TITLE
Add org.metaborg.meta.lang.template.test (SDF3 SPT tests) to integrationtest build step

### DIFF
--- a/build/integrationtest/pom.xml
+++ b/build/integrationtest/pom.xml
@@ -24,6 +24,7 @@
 
   <modules>
     <module>${repo.root}/sdf/org.metaborg.sdf.meta.integrationtest</module>
+    <module>${repo.root}/sdf/org.metaborg.meta.lang.template.test</module>
     <module>${repo.root}/jsglr/org.spoofax.jsglr2.integrationtest</module>
     <module>${repo.root}/spt/org.metaborg.spt.integrationtest</module>
     <module>${repo.root}/nabl/nabl2.test</module>

--- a/build/integrationtest/pom.xml
+++ b/build/integrationtest/pom.xml
@@ -23,6 +23,7 @@
   </properties>
 
   <modules>
+    <module>${repo.root}/mb-rep/org.metaborg.meta.lang.aterm.test</module>
     <module>${repo.root}/sdf/org.metaborg.sdf.meta.integrationtest</module>
     <module>${repo.root}/sdf/org.metaborg.meta.lang.template.test</module>
     <module>${repo.root}/jsglr/org.spoofax.jsglr2.integrationtest</module>


### PR DESCRIPTION
I had added [some SPT tests](https://github.com/metaborg/sdf/pull/38/files#diff-a8a8941d7d6507e0e57998290d17a78f) to SDF3 in metaborg/sdf#38, and to my surprise, they were never executed in the full build (even though there were already [existing SPT tests for SDF3](https://github.com/metaborg/sdf/blob/develop/jsglr2/org.metaborg.meta.lang.template.test/test.spt)).

This PR enables the running of SPT tests for SDF3 during the `integrationtest` step of the build. ~Can be merged independently of the other Unicode PRs.~