### PR TITLE
Add sdf3.ext.statix project to build

### DIFF
--- a/build/eclipse/pom.xml
+++ b/build/eclipse/pom.xml
@@ -51,6 +51,7 @@
     <module>${repo.root}/runtime-libraries/org.metaborg.meta.lib.analysis.eclipse</module>
     <module>${repo.root}/sdf/org.metaborg.meta.lang.sdf.eclipse</module>
     <module>${repo.root}/sdf/org.metaborg.meta.lang.template.eclipse</module>
+    <module>${repo.root}/sdf/sdf3.ext.statix.eclipse</module>
     <module>${repo.root}/spt/org.metaborg.meta.lang.spt.eclipse</module>
     <module>${repo.root}/spt/org.metaborg.meta.lang.spt.interactive.eclipse</module>
     <module>${repo.root}/stratego/org.metaborg.meta.lang.stratego.eclipse</module>

--- a/build/language/pom.xml
+++ b/build/language/pom.xml
@@ -36,6 +36,7 @@
     <module>${repo.root}/runtime-libraries/org.metaborg.meta.lib.analysis</module>
     <module>${repo.root}/sdf/org.metaborg.meta.lang.sdf</module>
     <module>${repo.root}/sdf/org.metaborg.meta.lang.template</module>
+    <module>${repo.root}/sdf/sdf3.ext.statix</module>
     <module>${repo.root}/stratego/org.metaborg.meta.lang.stratego</module>
     <module>${repo.root}/ts/org.metaborg.meta.lang.ts</module>
     <module>${repo.root}/metaborg-coq/org.metaborg.lang.coq</module>


### PR DESCRIPTION
Adding this causes the `org.metaborg.core.build.Builder` to perform the transformations on all projects. This needs to be fixed first.

Depends on:
- metaborg/spoofax-eclipse#16