### PR TITLE
Robust file resolution

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,7 +141,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-vfs2</artifactId>
-        <version>2.2</version>
+        <version>2.6.0</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>


### PR DESCRIPTION
The method `FileObject::resolveFile(String)` does not support absolute paths as
argument that are outside the file system of the base file. These PRs (in `releng`,
`mb-exec` and `spoofax`) replace uses of that method with the utility method
`ResourceUtils::resolveFile(FileObject, String)` that _does_ support cross file system
absolute paths.

This PR bumps to `commons`vfs2` version from the Oct 2017 2.2 release to the latest Jan 2020 2.6.0 release.