### PR TITLE
./b command: Replace virtualenv with venv

### DIFF
--- a/releng/.gitignore
+++ b/releng/.gitignore
@@ -1,4 +1,4 @@
-/.virtualenv
+/.venv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/releng/requirements_virtualenv.txt
+++ b/releng/requirements_virtualenv.txt
@@ -1,1 +1,0 @@
-virtualenv==20.0.15

--- a/releng/run.sh
+++ b/releng/run.sh
@@ -16,16 +16,29 @@ fi
 
 VENV="$DIR/.venv"
 
-# Create virtual environment
+# Create virtual environment, if it does not exist yet
 if [[ ! -d "$VENV" ]]
 then
-    if ! $PYTHON_CMD -m venv "$VENV" > /dev/null
+    # On Ubuntu/Debian, Python3 does not automatically come with ensurepip installed
+    # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847/+index?comments=all
+    # Note that the issue is marked as "fixed", but it's still broken.
+    if ! $PYTHON_CMD -c 'help("modules")' 2> /dev/null | grep ensurepip
     then
-        # On Ubuntu/Debian, Python3 does not automatically come with ensurepip installed, so we install it manually:
-        # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847/+index?comments=all (comment #58)
-        $PYTHON_CMD -m venv --without-pip "$VENV" > /dev/null
-        curl -s https://bootstrap.pypa.io/get-pip.py | "$VENV/bin/python" > /dev/null
+        echo "Could not find the 'ensurepip' module, which is required for creating a"
+        echo "Python virtual environment. There are a few options to fix this, for example:"
+        echo "- Install python3-venv using your system's package manager, e.g.:"
+        # This fix comes from comments #63-64 on the Ubuntu bug report
+        echo "    sudo apt install python3-venv"
+        echo "- Create the virtual environment manually without Pip and install Pip inside it:"
+        # This fix comes from comment #58 on the Ubuntu bug report
+        echo "    $PYTHON_CMD -m venv --without-pip \"$VENV\""
+        echo "    curl -s https://bootstrap.pypa.io/get-pip.py | \"$VENV/bin/python\""
+        echo "After executing one of these options, you can re-run this command."
+        exit 1
     fi
+
+    # This command is silent by itself, but errors (if any) are printed to stdout
+    $PYTHON_CMD -m venv "$VENV"
 fi
 
 # Activate virtual environment

--- a/releng/run.sh
+++ b/releng/run.sh
@@ -14,16 +14,22 @@ else
   exit 1
 fi
 
-# Ensure that virtualenv is installed and updated
-$PYTHON_CMD -m pip install --quiet --user --upgrade --requirement "$DIR/requirements_virtualenv.txt"
+VENV="$DIR/.venv"
 
-# Create and activate virtualenv
-VENV="$DIR/.virtualenv"
-$PYTHON_CMD -m virtualenv --quiet "$VENV" > /dev/null
-# Since virtualenv is made by idiots, temporarily disable unbound variable checks when activating virtualenv
-set +o nounset
+# Create virtual environment
+if [[ ! -d "$VENV" ]]
+then
+    if ! $PYTHON_CMD -m venv "$VENV" > /dev/null
+    then
+        # On Ubuntu/Debian, Python3 does not automatically come with ensurepip installed, so we install it manually:
+        # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847/+index?comments=all (comment #58)
+        $PYTHON_CMD -m venv --without-pip "$VENV" > /dev/null
+        curl -s https://bootstrap.pypa.io/get-pip.py | "$VENV/bin/python" > /dev/null
+    fi
+fi
+
+# Activate virtual environment
 source "$VENV/bin/activate"
-set -o nounset
 
 # Install requirements
 $PYTHON_CMD -m pip install --quiet --requirement "$DIR/requirements.txt"


### PR DESCRIPTION
@Gohla As discussed on Slack: a setup where `virtualenv` is replaced by `venv` :slightly_smiling_face: 

On most operating systems, this should work out-of-the-box by just installing Python 3 and nothing else. Also, nothing is installed in the global Python environment, which should at least partially prevent [this](https://xkcd.com/1987/). This is also updated in the documentation: metaborg/documentation#39.

I've changed the name of the virtual environment directory from `.virtualenv` to `.venv`, to prevent things from clashing. This means that developers will get an untracked `.virtualenv` directory in their `releng` submodule, but that shouldn't harm anything. Rather, it will be easier to switch back if necessary.

Inside the virtual environment, Pip is installed (and `venv` should automatically upgrade it to the latest version). This, of course, would require either installing `python3-pip` or using an existing global `pip` to install a Pip in the virtual environment, but if that fails, the script will use [get-pip.py](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py) instead.
One small side-note: for some reason, the Debian package maintainers decided to not include Python's full standard library when `apt install`-ing `python3`. Installing Pip inside the virtual environment requires the `distutils` module, which will need to be installed separately on these systems. In most cases, developers will have already installed this module without knowing (e.g. via `python3-dev`, `python3-pip`, or `python3-venv`), but just in case, I've added a note about this in the documentation.

I've tested this on my own machine (Xubuntu 20.04, with `python3` and `python3-pip` installed), inside a clean Docker container based on Ubuntu 20.04 (after installing `python3-dev` in it), and using an Arch Linux box on https://distrotest.net/Archlinux (which does not have an internet connection so I didn't bother setting up Spoofax in it, but I manually ran the creation of the virtual environment to verify that that works).
I would appreciate it if others also test this on other operating systems, and please indicate how the virtual environment is created. One way to see this, would be to run `./b -v` with the following print statements in the `run.sh` script: <details>
<summary>Apply this diff using `git apply`</summary>

```diff
diff --git a/releng/run.sh b/releng/run.sh
index 1893a99..5c544ce 100755
--- a/releng/run.sh
+++ b/releng/run.sh
@@ -19,8 +19,10 @@ VENV="$DIR/.venv"
 # Create virtual environment
 if [[ ! -d "$VENV" ]]
 then
+    echo "Creating virtual environment releng/releng/.venv"
     if ! $PYTHON_CMD -m venv "$VENV" > /dev/null
     then
+        echo "Using --without-pip and calling get-pip"
         # On Ubuntu/Debian, Python3 does not automatically come with ensurepip installed, so we install it manually:
         # https://bugs.launchpad.net/ubuntu/+source/python3.4/+bug/1290847/+index?comments=all (comment #58)
         $PYTHON_CMD -m venv --without-pip "$VENV" > /dev/null
```
</details>

On my machine, both lines are printed the first time running `./b -v`, and it takes about ten seconds to download and install Pip. However, subsequent runs do not print these lines, and the script finishes within half a second. 