### PR TITLE
Add nativebundle as project

### DIFF
--- a/gradle/java/settings.gradle.kts
+++ b/gradle/java/settings.gradle.kts
@@ -93,6 +93,7 @@ if(repositoryConfigurations.isUpdated("spoofax2")) {
     includeProject("org.metaborg.spoofax.core")
     includeProject("org.metaborg.meta.core")
     includeProject("org.metaborg.spoofax.meta.core")
+    includeProject("org.metaborg.spoofax.nativebundle")
   }
 }
 


### PR DESCRIPTION
This PR adds `org.metaborg.spoofax.nativebundle` as a Gradle project.